### PR TITLE
Fixed the crashing of screen recorder on cancel

### DIFF
--- a/app/src/main/java/cmu/xprize/robotutor/RoboTutor.java
+++ b/app/src/main/java/cmu/xprize/robotutor/RoboTutor.java
@@ -131,6 +131,7 @@ public class RoboTutor extends Activity implements IReadyListener, IRoboTutor {
 
     // deprecated variable , see issue #427
     public static final boolean OLD_MENU = true;
+    public static final int REQUEST_CODE = 1;
 
 
     private CMediaController    mMediaController;
@@ -309,7 +310,7 @@ public class RoboTutor extends Activity implements IReadyListener, IRoboTutor {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (data != null)
+        if (data != null && requestCode == REQUEST_CODE && resultCode == RESULT_OK)
             screenRecorder.onActivityResult(requestCode, resultCode, data);
         setFullScreen();
     }


### PR DESCRIPTION
Fixes #46 

This PR fixes the hang of the screen recorder when the cancel button was pressed.