### PR TITLE
Fix for handling stale cache assets

### DIFF
--- a/app/src/main/java/cmu/xprize/robotutor/RoboTutor.java
+++ b/app/src/main/java/cmu/xprize/robotutor/RoboTutor.java
@@ -665,7 +665,8 @@ public class RoboTutor extends Activity implements IReadyListener, IRoboTutor, H
                     logManager.postEvent_V(TAG, "INFO:Tutor Assets installed");
                 }
 
-                if(!tutorAssetManager.fileCheck(TCONST.LTK_PROJECT_ASSETS)) {
+                if(!tutorAssetManager.fileCheck(TCONST.LTK_PROJECT_ASSETS) ||
+                        tutorAssetManager.fileIsStale(TCONST.LTK_PROJEXCTS, TCONST.LTK_PROJECT_ASSETS)) {
                     tutorAssetManager.installAssets(TCONST.LTK_PROJEXCTS);
                     logManager.postEvent_V(TAG, "INFO:LTK Projects installed");
 
@@ -676,7 +677,8 @@ public class RoboTutor extends Activity implements IReadyListener, IRoboTutor, H
                     logManager.postEvent_V(TAG, "INFO:LTK Projects extracted");
                 }
 
-                if(!tutorAssetManager.fileCheck(TCONST.LTK_GLYPH_ASSETS)) {
+                if(!tutorAssetManager.fileCheck(TCONST.LTK_GLYPH_ASSETS) ||
+                tutorAssetManager.fileIsStale(TCONST.LTK_GLYPHS, TCONST.LTK_GLYPH_ASSETS)) {
                     tutorAssetManager.installAssets(TCONST.LTK_GLYPHS);
                     logManager.postEvent_V(TAG, "INFO:LTK Glyphs installed");
 

--- a/app/src/main/java/cmu/xprize/robotutor/tutorengine/CTutorAssetManager.java
+++ b/app/src/main/java/cmu/xprize/robotutor/tutorengine/CTutorAssetManager.java
@@ -30,6 +30,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -130,6 +134,35 @@ public class CTutorAssetManager {
         File projects = new File(RoboTutor.APP_PRIVATE_FILES + "/" + path);
 
         return projects.exists();
+    }
+
+    public boolean fileIsStale(String downloadedAsset, String unzippedAsset) {
+        try {
+            String path_downloaded = RoboTutor.APP_PRIVATE_FILES + "/" + downloadedAsset;
+            String path_unzipped = RoboTutor.APP_PRIVATE_FILES + "/" + unzippedAsset;
+
+            File file_downloaded = new File(path_downloaded);
+            File file_unzipped = new File(path_unzipped);
+
+            BasicFileAttributes attr_downloaded = Files.readAttributes(Paths.get(file_downloaded.getPath()), BasicFileAttributes.class);
+            BasicFileAttributes attr_unzipped = Files.readAttributes(Paths.get(file_unzipped.getPath()), BasicFileAttributes.class);
+
+            FileTime time_downloaded = attr_downloaded.creationTime();
+            FileTime time_unzipped = attr_unzipped.creationTime();
+
+            Log.d(TAG, "fileIsNotStale: downloadTime = " + time_downloaded + " unzip time = " + time_unzipped);
+
+            if (time_downloaded.compareTo(time_unzipped) > 0) {
+                // time_downloaded - time_unzipped > 0
+                // file is stale
+                return true;
+            } else {
+                return false;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return true;
+        }
     }
 
 


### PR DESCRIPTION
# PR Info

## Issue Details
 Downloading updated assets does not make RoboTutor unzip and install them in place of stale cached assets.
<!-- Please choose the relevant option -->

 - **Fixes**:  `fileIsStale()` method added

## Branch
 - **Addresses** `development` <!-- Please change this if your PR is targetting other branches -->

## Type of change

<!-- Please delete options that are not relevant -->

- **Bug Fix** <!--  non-breaking change which fixes an issue -->
- **New Feature** <!-- non-breaking change which adds functionality -->
- **Breaking Change** <!-- fix or feature that would cause existing functionality to not work as expected -->
- **Other** <!-- please specify -->

## Additional Info

<!-- Any additional info we should know about the PR! -->