### PR TITLE
2023 02 01 bhargav add stack trace

### DIFF
--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -764,7 +764,6 @@ public class CLogManagerBase implements ILogManager {
 
     @Override
     public void postPacket(String packet) {
-
         post(packet);
     }
 }

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -379,6 +379,7 @@ public class CLogManagerBase implements ILogManager {
     }
 
     private String getSequenceId() {
+        //Example RoboTutor__3.5.0.1_000019_2023.02.15.22.05.05_unknown : in this example 000019 is being extracted which occurs between 3rd and 4th underscore.
        int cnt = 0;
        String sequenceId="";
        for(int i=0;i<log_Filename.length();i++){

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -380,7 +380,7 @@ public class CLogManagerBase implements ILogManager {
        int cnt = 0;
        String sequenceId="";
        for(int i=0;i<log_Filename.length();i++){
-           if(cnt == 2){
+           if(cnt == 3){
                for(int j=i;j<log_Filename.length();j++){
                    if(log_Filename.charAt(j) == '_') break;
                    sequenceId += log_Filename.charAt(j);

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -30,7 +30,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.io.RandomAccessFile;
+import java.io.StringWriter;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -68,7 +70,7 @@ public class CLogManagerBase implements ILogManager {
 
     private boolean                    logWriterValid = false;
 
-    //this is a dummy commit
+
     // Datashop specific
 
     private boolean                    loggingDS = false;
@@ -619,6 +621,10 @@ public class CLogManagerBase implements ILogManager {
     public void postError(String Tag, String Msg, Exception e) {
 
         String packet;
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        String stackTrace = sw.toString().replace('\n',';');
 
         packet = "{" +
                 "\"class\":\"ERROR\"," +
@@ -626,7 +632,8 @@ public class CLogManagerBase implements ILogManager {
                 "\"type\":\"Exception\"," +
                 "\"time\":\"" + System.currentTimeMillis() + "\"," +
                 "\"msg\":\"" + Msg + "\"," +
-                "\"exception\":\"" + e.toString() + "\"" +
+                "\"exception\":\"" + e.toString() + "\"," +
+                "\"stack_trace\":\"" + stackTrace + "\"" +
                 "},\n";
 
         post(packet);

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -68,6 +68,7 @@ public class CLogManagerBase implements ILogManager {
 
     private boolean                    logWriterValid = false;
 
+    //this is a dummy commit
     // Datashop specific
 
     private boolean                    loggingDS = false;

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -347,12 +347,16 @@ public class CLogManagerBase implements ILogManager {
         try {
             String deviceId = Build.SERIAL;
             String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-            String _directory = Environment.getExternalStorageDirectory() + "/RoboTutor_ERROR/";
+            String _directory = Environment.getExternalStorageDirectory() + "/RoboTutor/";
             File logFileDir = new File(_directory);
             if(!logFileDir.exists()){
                 logFileDir.mkdirs(); // incase RoboTutor folder is nonexistent
             }
-
+            _directory = _directory + "/RoboTutor_ERROR/";
+            logFileDir = new File(_directory);
+            if(!logFileDir.exists()){
+                logFileDir.mkdirs(); // incase RoboTutor folder is nonexistent
+            }
             //Add version how ?? BuildConfig.VERSION_NAME + "_" not working for this package need to get version from robotutor
             File logFile = new File(_directory + "ERROR_RoboTutor_" + BuildConfig.BUILD_TYPE + "_" +
                     //RoboTutor.SEQUENCE_ID_STRING + "_" +

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -84,6 +84,7 @@ public class CLogManagerBase implements ILogManager {
     private java.nio.channels.FileLock logDSLock;
     private FileWriter                 logDSWriter;
     private boolean                    logDSWriterValid = false;
+    protected static String sessionStartTime;
 
 
     protected String TAG = "CLogManagerBase";
@@ -96,6 +97,7 @@ public class CLogManagerBase implements ILogManager {
 
         log_Path = logPath;
         log_Filename = logFilename;
+        sessionStartTime = new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date());
 
         // Restart the log if necessary
         //
@@ -362,7 +364,7 @@ public class CLogManagerBase implements ILogManager {
             }
 
 
-            File logFile = new File(_directory + "ERROR_RoboTutor_" + BuildConfig.BUILD_TYPE + "_" +
+            File logFile = new File(_directory + "ERROR_RoboTutor_" + sessionStartTime +"_" + BuildConfig.BUILD_TYPE + "_" +
                     getSequenceId() + "_" +
                     timestamp + deviceId + ".txt");
             logFile.createNewFile();

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -97,7 +97,7 @@ public class CLogManagerBase implements ILogManager {
 
         log_Path = logPath;
         log_Filename = logFilename;
-        sessionStartTime = new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date());
+        sessionStartTime = new SimpleDateFormat("yyyyMMdd_HHmmss.SSS").format(new Date());
 
         // Restart the log if necessary
         //
@@ -351,7 +351,7 @@ public class CLogManagerBase implements ILogManager {
     private void createErrorFile(String report,String msg) {
         try {
             String deviceId = Build.SERIAL;
-            String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss.sss").format(new Date());
+            String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss.SSS").format(new Date());
             String _directory = Environment.getExternalStorageDirectory() + "/RoboTutor/";
             File logFileDir = new File(_directory);
             if(!logFileDir.exists()){

--- a/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
+++ b/comp_logging/src/main/java/cmu/xprize/comp_logging/CLogManagerBase.java
@@ -18,11 +18,14 @@
 
 package cmu.xprize.comp_logging;
 
+import android.app.Activity;
 import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Log;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -346,7 +349,7 @@ public class CLogManagerBase implements ILogManager {
     private void createErrorFile(String report,String msg) {
         try {
             String deviceId = Build.SERIAL;
-            String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+            String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss.sss").format(new Date());
             String _directory = Environment.getExternalStorageDirectory() + "/RoboTutor/";
             File logFileDir = new File(_directory);
             if(!logFileDir.exists()){
@@ -357,9 +360,10 @@ public class CLogManagerBase implements ILogManager {
             if(!logFileDir.exists()){
                 logFileDir.mkdirs(); // incase RoboTutor folder is nonexistent
             }
-            //Add version how ?? BuildConfig.VERSION_NAME + "_" not working for this package need to get version from robotutor
+
+
             File logFile = new File(_directory + "ERROR_RoboTutor_" + BuildConfig.BUILD_TYPE + "_" +
-                    //RoboTutor.SEQUENCE_ID_STRING + "_" +
+                    getSequenceId() + "_" +
                     timestamp + deviceId + ".txt");
             logFile.createNewFile();
             FileOutputStream trace = new FileOutputStream(logFile, false);
@@ -369,6 +373,23 @@ public class CLogManagerBase implements ILogManager {
             Log.d("CEF",ioe.getMessage());
             ioe.printStackTrace();
         }
+
+    }
+
+    private String getSequenceId() {
+       int cnt = 0;
+       String sequenceId="";
+       for(int i=0;i<log_Filename.length();i++){
+           if(cnt == 2){
+               for(int j=i;j<log_Filename.length();j++){
+                   if(log_Filename.charAt(j) == '_') break;
+                   sequenceId += log_Filename.charAt(j);
+               }
+               break;
+           }
+           if(log_Filename.charAt(i) == '_') cnt++;
+       }
+       return sequenceId;
     }
 
 


### PR DESCRIPTION
1)Dumped stack trace in existing postError function previously just for stack-tracing CRASH.
2) Implemented error log creation similar to crash logs for each ERROR. All the ERROR_log.txt files are being stored in Robotutor_ERROR directory. --> don't want to have to change DriveSync FOLDER PAIRS on tablets.  Options:
a. Dump directly to same folder as crash_logs.
b. Make robotutor_error folder under crash_logs.
c. Make robotutor_error folder under tablet top-level RoboTutor folder where logs go and get uploaded. --> DO THIS

ERROR_LOG filepath and filename format:
path:  [device storage, e.g. /storage/emulated/0]/RoboTutor/RoboTutor_ERROR/
filename:  ERROR_RoboTutor_version_device ID _session sequence number_ session start time_error time_"sanitized" error message

"sanitize" = start...end or #hash

      java.lang.ClassCastException: cmu.xprize.robotutor.tutorengine.widgets.core.TStudentProfileModal cannot be cast to cmu.xprize.robotutor.tutorengine.ITutorObject

--------- Stack trace ---------

    cmu.xprize.robotutor.tutorengine.CTutor.mapChildren(CTutor.java:740)
    cmu.xprize.robotutor.tutorengine.CTutor.automateScene(CTutor.java:707)
    cmu.xprize.robotutor.tutorengine.CTutor.instantiateScene(CTutor.java:682)
    cmu.xprize.robotutor.tutorengine.CTutorGraph.gotoNextScene(CTutorGraph.java:448)
    cmu.xprize.robotutor.tutorengine.CTutorGraph$Queue.run(CTutorGraph.java:203)
    android.os.Handler.handleCallback(Handler.java:938)
    android.os.Handler.dispatchMessage(Handler.java:99)
    android.os.Looper.loop(Looper.java:223)
    android.app.ActivityThread.main(ActivityThread.java:7656)
    java.lang.reflect.Method.invoke(Native Method)
    com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
    com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
-------------------------------

--------- Cause ---------

-------------------------------
