### PR TITLE
2023 03 19 Rishideep - updating keystore properties file path

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,9 @@ android {
 
     // Create a variable called keystorePropertiesFile, and initialize it to your
     // keystore.properties file, in the rootProject folder.
-    def keystorePropertiesFile = rootProject.file("/home/runner/work/RoboTutor_2020/RoboTutor_2020/app/src/sample_config_files/sample_keystore.properties")
+    def keystorePropertiesFile = rootProject.file("app/src/sample_config_files/sample_keystore.properties")
+
+//    def keystorePropertiesFile = rootProject.file("/home/runner/work/RoboTutor_2020/RoboTutor_2020/app/src/sample_config_files/sample_keystore.properties")
 
     // Initialize a new Properties() object called keystoreProperties
     def keystoreProperties = new Properties()


### PR DESCRIPTION
Hello @JackMostow Sir!

Updated the keystore.properties file path as 'app/src/sample_config_files/sample_keystore.properties' instead of specifying the absolute path, since GitHub Actions already traverses till the root directory by default.

The earlier path (absolute), "/home/runner/work/RoboTutor_2020/RoboTutor_2020/app/src/sample_config_files/sample_keystore.properties" was specific to the GitHub virtual environment, and might have caused issues when running the 'build.gradle' file manually.

Thanks - Rishideep!