### PR TITLE
2023 03 16 rishideep screen recording and crash log filename link session log

### DIFF
--- a/app/src/main/java/cmu/xprize/robotutor/ScreenRecorder.java
+++ b/app/src/main/java/cmu/xprize/robotutor/ScreenRecorder.java
@@ -25,6 +25,8 @@ import java.util.Date;
 import java.util.Vector;
 import java.text.SimpleDateFormat;
 
+import cmu.xprize.robotutor.RoboTutor;
+
 class AudioObject {
     String path = "";
     Date startDate = null;
@@ -127,7 +129,8 @@ public class ScreenRecorder {
         String currDate = formatter.format(new Date()).replace('/','_').replace(':','_').replace(' ','_');
         String timeInString = Long.toString(time);
         String formattedTutorId = tutorId.replace(":","_").replace(".","_");
-        this.saveName = formattedTutorId+"_"+currDate+"_"+timeInString;
+//        this.saveName = formattedTutorId+"_"+currDate+"_"+timeInString+"_"+RoboTutor.SESSION_ID;
+        this.saveName = currDate + "_" + timeInString + "_" + RoboTutor.SESSION_ID + "_" + formattedTutorId;
         Log.d(TAG, "startRecording: "+this.saveName);
         if (this.recorderInstance == null) {
             this.recorderInstance = new ScreenRecordHelper(this.activity, null,

--- a/app/src/main/java/cmu/xprize/robotutor/ScreenRecorder.java
+++ b/app/src/main/java/cmu/xprize/robotutor/ScreenRecorder.java
@@ -25,8 +25,6 @@ import java.util.Date;
 import java.util.Vector;
 import java.text.SimpleDateFormat;
 
-import cmu.xprize.robotutor.RoboTutor;
-
 class AudioObject {
     String path = "";
     Date startDate = null;

--- a/app/src/main/java/cmu/xprize/robotutor/tutorengine/util/CrashHandler.java
+++ b/app/src/main/java/cmu/xprize/robotutor/tutorengine/util/CrashHandler.java
@@ -8,6 +8,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import cmu.xprize.robotutor.BuildConfig;
 import cmu.xprize.robotutor.RoboTutor;
@@ -34,6 +36,10 @@ public class CrashHandler implements Thread.UncaughtExceptionHandler {
         activity.hbRecorder.stopScreenRecording();
         StackTraceElement[] arr = e.getStackTrace();
         String report = e.toString()+"\n\n";
+        Pattern exceptionPattern = Pattern.compile("([a-zA-Z]+)\\s*:");
+        Matcher matcher = exceptionPattern.matcher(report);
+        matcher.find();
+        String errorMessage = matcher.group(1);
         report += "--------- Stack trace ---------\n\n";
         for (int i=0; i<arr.length; i++) {
             report += "    "+arr[i].toString()+"\n";
@@ -60,7 +66,7 @@ public class CrashHandler implements Thread.UncaughtExceptionHandler {
             }
             File logFile = new File(_directory + "CRASH_RoboTutor_" + BuildConfig.BUILD_TYPE + "_" + BuildConfig.VERSION_NAME + "_" +
                     //RoboTutor.SEQUENCE_ID_STRING + "_" +
-                     timestamp + deviceId + ".txt");
+                     timestamp + "_" + RoboTutor.SESSION_ID + "_" + errorMessage + ".txt");
             logFile.createNewFile();
             FileOutputStream trace = new FileOutputStream(logFile, false);
             trace.write(report.getBytes());


### PR DESCRIPTION
### 1. Linked screenRecording filename to sessionLog
    New filename format: "date_time_sessionID_tutorID.mp4"

### 2. Linked crashLog filename to sessionLog
    New filename format: "CRASH_RoboTutor_buildType_versionName_timestamp_sessionID_errorMessage.txt"

    Extracted the initial error message (exception) for the new format, example- `NullPointerException` using Java regex classes Pattern and Matcher.

